### PR TITLE
make `lpad new-post -p` work

### DIFF
--- a/lib/lambdapad/cli/command/new_post.ex
+++ b/lib/lambdapad/cli/command/new_post.ex
@@ -146,7 +146,7 @@ defmodule Lambdapad.Cli.Command.NewPost do
 
     path_fmt =
       config["blog"]["posts_path"] ||
-        params[:"posts-path"] ||
+        params[:"posts-dir"] ||
         @default_posts_path
 
     {rel_path, _} = Code.eval_string(~s|"#{path_fmt}"|, bindings)


### PR DESCRIPTION
When I ran `lpad new-post lady-locks -b "title=Lady Locks, Veganized" -b "category=Personal" -p "posts/#{slug}.md"` I got:

```
* Reading configuration: lambdapad.exs
  - Compiling lambdapad.exs
  - Create directory
    - /Users/maco/code/blog/posts/2025/10/18
  Done (0.152s)
* Create source for post:
  - lady-locks.md
  Done (0.001s)
Done (0.153s)
```

But that wasn't what I wanted. I expected my file to end up directly under `posts/`. Turns out, the argument is captured into one name but looked up as a different name.
